### PR TITLE
Fix load event name

### DIFF
--- a/lib/kaminari/activegraph/hooks.rb
+++ b/lib/kaminari/activegraph/hooks.rb
@@ -2,7 +2,7 @@ module Kaminari
   module ActiveGraph
     class Hooks
       def self.init
-        ActiveSupport.on_load(:active_node) do
+        ActiveSupport.on_load(:node) do
           ::ActiveGraph::Core::Query.send :include, Kaminari::ActiveGraph::Extension::InstanceMethods
           ::ActiveGraph::Node::Query::QueryProxy.send :include, Kaminari::ActiveGraph::Extension::InstanceMethods
           ::ActiveGraph::Node.send :include, Kaminari::ActiveGraph::Extension::ClassMethods


### PR DESCRIPTION
This pull request addresses a key modification in the initialization process of the ActiveGraph module, specifically within the Hooks class's init method. The primary change involves adjusting the ActiveSupport load hook to align with the correct namespace.

- https://github.com/neo4jrb/activegraph/blob/8e2ba4d117f5702633b0aa7099c71923a100c40d/lib/active_graph/node.rb#L109

Additionally, it has come to our attention that this package does not appear to be registered on RubyGems yet. We kindly request that the necessary steps be taken to ensure its registration. We appreciate your attention to this matter and look forward to seeing the package available on RubyGems.